### PR TITLE
Fixed: data.sql, schema, JPA Data Ini. & more

### DIFF
--- a/src/main/java/vortex/imwp/Models/Employee.java
+++ b/src/main/java/vortex/imwp/Models/Employee.java
@@ -10,16 +10,27 @@ public class Employee {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(unique = true, nullable = false)
     private String username;
+    @Column(nullable = false)
     private String password;
+    @Column(nullable = false)
     private String name;
+    @Column(nullable = false)
     private String surname;
+    @Column(nullable = false)
     private Date dob;
+    @Column(nullable = false)
     private String phone;
+    @Column(nullable = false)
     private String email;
+    @Column(name = "Start_Date", nullable = false)
     private Date startDate;
+    @Column(name = "End_Date")
     private Date endDate;
+    @Column(name = "Warehouse_ID", nullable = false)
     private Long warehouseID;
+    @Column(name = "Boss_ID")
     private Long bossID;
 
     @ManyToMany

--- a/src/main/java/vortex/imwp/Repositories/EmployeeRepository.java
+++ b/src/main/java/vortex/imwp/Repositories/EmployeeRepository.java
@@ -1,5 +1,6 @@
 package vortex.imwp.Repositories;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
@@ -9,7 +10,7 @@ import vortex.imwp.Models.Employee;
 import java.util.Optional;
 
 @Repository
-public interface EmployeeRepository extends CrudRepository<Employee, Long> {
+public interface EmployeeRepository extends JpaRepository<Employee, Long> {
     Optional<Employee> findByUsername(String username);
 
     @Query("SELECT e FROM Employee e LEFT JOIN FETCH e.jobs WHERE e.username = :username")

--- a/src/main/java/vortex/imwp/Repositories/JobRepository.java
+++ b/src/main/java/vortex/imwp/Repositories/JobRepository.java
@@ -6,4 +6,5 @@ import vortex.imwp.Models.Job;
 
 @Repository
 public interface JobRepository extends JpaRepository<Job, Long> {
+    public Job findById(long id);
 }

--- a/src/main/java/vortex/imwp/Services/EmployeeService.java
+++ b/src/main/java/vortex/imwp/Services/EmployeeService.java
@@ -9,15 +9,21 @@ import vortex.imwp.Models.Job;
 import vortex.imwp.Repositories.EmployeeRepository;
 import vortex.imwp.Repositories.JobRepository;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 @Service
 public class EmployeeService {
     private final EmployeeRepository employeeRepository;
     private final PasswordEncoder passwordEncoder;
-    public EmployeeService(EmployeeRepository employeeRepository, PasswordEncoder passwordEncoder) {
+    private final JobRepository jobRepository;
+    public EmployeeService(EmployeeRepository employeeRepository, PasswordEncoder passwordEncoder, JobRepository jobRepository) {
         this.employeeRepository = employeeRepository;
         this.passwordEncoder = passwordEncoder;
+        this.jobRepository = jobRepository;
     }
 
     public Optional<EmployeeDTO> getEmployeeByUsername(String username){
@@ -30,8 +36,15 @@ public class EmployeeService {
         user.setUsername(employee.getUsername());
         user.setEmail(employee.getEmail());
         user.setPassword(passwordEncoder.encode(employee.getPassword()));
+        user.setName("Name");
+        user.setSurname("Surname");
+        user.setDob(new Date());
+        user.setStartDate(new Date());
+        user.setPhone("TBD");
+        user.setBossID(0L);
+        user.setWarehouseID(0L);
+        user.addJob(jobRepository.findById(0L));
         employeeRepository.save(user);
-        System.out.println("Registered employee " + user.getUsername());
         return user;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,16 +4,17 @@ spring:
   datasource:
     url: jdbc:h2:mem:inventory_db;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver
-    username: sa
-    password:
+    username: admin
+    password: password
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         dialect: org.hibernate.dialect.H2Dialect
+    defer-datasource-initialization: true
   h2:
     console:
       enabled: true

--- a/src/main/resources/sql/data.sql
+++ b/src/main/resources/sql/data.sql
@@ -1,17 +1,19 @@
 -- Warehouses
-INSERT INTO Warehouse (Address) VALUES
-                                   ('123 Main St, Berlin'),
-                                   ('456 Market Ave, Munich');
+INSERT INTO Warehouse (ID, Address) VALUES
+                                   (0, 'TBD'),
+                                   (1, '123 Main St, Berlin'),
+                                   (2, '456 Market Ave, Munich');
 
 -- Jobs
 INSERT INTO Job (Name, Description) VALUES
+                                        ('TBD', 'To Be Determined'),
                                         ('Salesman', 'Handles customer purchases.'),
                                         ('Manager', 'Oversees operations.'),
                                         ('Stocker', 'Manages inventory.');
 
 -- Employees
-INSERT INTO Employee (Username, HashedPassword, Name, Surname, DoB, Email, Phone, Start_Date, End_Date, Boss_ID, Warehouse_ID) VALUES
-                                                                                                                                   ('jdoe', 'hashpass123', 'John', 'Doe', '1990-01-15', 'jdoe@example.com', '555-1111', '2020-01-01', NULL, NULL, 1),
+INSERT INTO Employee (Username, Password, Name, Surname, DoB, Email, Phone, Start_Date, End_Date, Boss_ID, Warehouse_ID) VALUES
+                                                                                                                                   ('admin', '$2a$10$Jj5/CMDhocYIWQX4r.93H.rfCkbsiQ3twLJZFd5osi9RyJe09VH7G', 'John', 'Doe', '1990-01-15', 'jdoe@example.com', '555-1111', '2020-01-01', NULL, NULL, 1),
                                                                                                                                    ('asmith', 'hashpass456', 'Alice', 'Smith', '1985-06-20', 'asmith@example.com', '555-2222', '2021-05-01', NULL, NULL, 2),
                                                                                                                                    ('bwayne', 'hashpass789', 'Bruce', 'Wayne', '1980-03-30', 'bwayne@example.com', '555-3333', '2019-11-15', NULL, 1, 1),
                                                                                                                                    ('ckent', 'hashpass999', 'Clark', 'Kent', '1992-07-10', 'ckent@example.com', '555-4444', '2023-02-01', NULL, 2, 2);

--- a/src/main/resources/sql/schema.sql
+++ b/src/main/resources/sql/schema.sql
@@ -3,7 +3,7 @@
 CREATE TABLE Employee (
                           ID BIGINT AUTO_INCREMENT PRIMARY KEY,
                           Username VARCHAR(50) NOT NULL,
-                          HashedPassword VARCHAR(100) NOT NULL,
+                          Password VARCHAR(100) NOT NULL,
                           Name VARCHAR(50) NOT NULL,
                           Surname VARCHAR(50) NOT NULL,
                           DoB DATE NOT NULL,


### PR DESCRIPTION
There were many core driving issues that lead to the data in _data.sql_ not being initialized (thus, the registered users couldn't be logged into). If you're wondering how I discovered this -> I attempted a query during runtime and was met with null data. So all the reasons that contributed to this not working were:

- _ddl-auto: create-drop_ caused Spring Boot to skip the **schema.sql** and instead initialized the database by itself
- When **EmployeeService** registered a new employee, it didn't (after changing ddl to _ddl-auto: none)_ actually save the employee because the schema required non-null fields, which we didn't provide with data (we saved it with null fields in earlier version) 

Thus the later changes implemented were to focus on fixing this:

-  _@Columns_ were used to identify correct column names
-  **JobRepository** has a new function to search jobs, that feeds it a **TBD** job field
- _data.sql_ now has many **TBD** fields in different entities that will serve as a temporary fill in
- Fields in **Employee** are tagged _@(nullable = false)_ accordingly

Other notable changes:
- Changed **EmployeeRepository** from _CRUD_ to _JPA_

So this luckily fixes the issue of data within _data.sql_ not being initialized. Now, for development purposes, we can use these logins below to experiment new features without having to register each single time 😄 :

username: admin
password: Qwerty7/

However, this raises an issue - we should force Employees that are registering to fill-in data during registration or ASAP after registration. We can contemplate the best approach later at a meeting.