### PR TITLE
Fixed: HTML Deprecation Issue

### DIFF
--- a/src/main/resources/templates/access-denied.html
+++ b/src/main/resources/templates/access-denied.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
   <title>Access Denied</title>
 </head>

--- a/src/main/resources/templates/admin/activity-log.html
+++ b/src/main/resources/templates/admin/activity-log.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
   <title>Activity Log</title>
 </head>

--- a/src/main/resources/templates/admin/admin-dashboard.html
+++ b/src/main/resources/templates/admin/admin-dashboard.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
   <title>Admin Dashboard</title>
 </head>

--- a/src/main/resources/templates/admin/register.html
+++ b/src/main/resources/templates/admin/register.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
     <title>Register New User</title>
 </head>

--- a/src/main/resources/templates/admin/user-management.html
+++ b/src/main/resources/templates/admin/user-management.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
   <title>User Management</title>
 </head>

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
     <title>Login</title>
 </head>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})">
+      th:replace="~{fragments/layout-noSearch :: layout(title=~{::title}, content=~{::section})}">
 <head>
   <title>Error</title>
 </head>

--- a/src/main/resources/templates/inventory/home.html
+++ b/src/main/resources/templates/inventory/home.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout :: layout(~{::title}, ~{::section})">
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::section})}">
 <head>
     <title th:fragment="title">Inventory Home</title>
 </head>

--- a/src/main/resources/templates/inventory/search-results.html
+++ b/src/main/resources/templates/inventory/search-results.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
-      th:replace="fragments/layout :: layout(~{::title}, ~{::section})">
+      th:replace="~{fragments/layout :: layout(~{::title}, ~{::section})}">
 
 <head>
   <title th:fragment="title">Search Results</title>


### PR DESCRIPTION
In most instances of our HTML pages, I fixed the html deprecation issue that mainly needed ~{} to be enwrapped over contents of th:replace=content.